### PR TITLE
chore: add dalink custom funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-custom: ['https://boosty.to/0xffff']
+custom: ['https://dalink.to/b4tman1', 'https://boosty.to/0xffff']


### PR DESCRIPTION
### Motivation
- Add `https://dalink.to/b4tman1` as a custom sponsorship option so it appears first in the repository funding UI.

### Description
- Updated ` .github/FUNDING.yml` to prepend `https://dalink.to/b4tman1` to the `custom` list and committed the change with a message that includes `[skip ci]`.

### Testing
- Ran `cat .github/FUNDING.yml` and `git log -1 --pretty=%s` to verify the file contents and commit message, and both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b3e528b67c832ebc2fd3f81d8e4d0e)